### PR TITLE
Enhance GameManager and UIManager to handle win/lose states and updat…

### DIFF
--- a/Assets/Main/PlayScene.unity
+++ b/Assets/Main/PlayScene.unity
@@ -287,11 +287,11 @@ RectTransform:
   - {fileID: 1718537598}
   m_Father: {fileID: 1407223604}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -221}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 30}
   m_SizeDelta: {x: 440, y: 90}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &68855871
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -962,7 +962,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 740.28, y: 109.13}
+  m_SizeDelta: {x: 740.28, y: 109.130005}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &720373510
 MonoBehaviour:
@@ -977,7 +977,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.62352943, g: 0.26730838, b: 0.23137252, a: 1}
+  m_Color: {r: 0.2035867, g: 0.5754717, b: 0.2035867, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1038,11 +1038,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1407223604}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 233.0975}
-  m_SizeDelta: {x: 740.28, y: 125.61}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.097473145}
+  m_SizeDelta: {x: 740.28, y: 125.609985}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &975702701
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1352,42 +1352,6 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!1 &1051754631
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1051754632}
-  m_Layer: 5
-  m_Name: GameOver
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1051754632
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1051754631}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1407223604}
-  m_Father: {fileID: 1807839875}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 31.902496}
-  m_SizeDelta: {x: 740.28, y: 591.805}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1132068625
 GameObject:
   m_ObjectHideFlags: 0
@@ -1832,12 +1796,12 @@ GameObject:
   - component: {fileID: 1407223606}
   - component: {fileID: 1407223605}
   m_Layer: 5
-  m_Name: Panel
+  m_Name: GameOver
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1407223604
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1845,7 +1809,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1407223603}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1853,12 +1817,12 @@ RectTransform:
   - {fileID: 975702700}
   - {fileID: 720373509}
   - {fileID: 68855870}
-  m_Father: {fileID: 1051754632}
+  m_Father: {fileID: 1807839875}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 31.902527}
+  m_SizeDelta: {x: -1179.72, y: -347.09613}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1407223605
 MonoBehaviour:
@@ -2084,7 +2048,7 @@ RectTransform:
   m_Children:
   - {fileID: 248709188}
   - {fileID: 1132068626}
-  - {fileID: 1051754632}
+  - {fileID: 1407223604}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2105,7 +2069,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   startUI: {fileID: 1132068625}
-  gameOverUI: {fileID: 1051754631}
+  gameOverUI: {fileID: 1407223603}
+  gameOverMessageContener: {fileID: 720373510}
 --- !u!1001 &1847648575
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Main/Scripts/GameManager.cs
+++ b/Assets/Main/Scripts/GameManager.cs
@@ -1,8 +1,9 @@
+using NUnit.Framework;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public static event System.Action OnGameOver;
+    public static event System.Action<bool> OnGameOver;
 
     [SerializeField] GameObject player;
     [SerializeField] GameObject soap;
@@ -25,13 +26,17 @@ public class GameManager : MonoBehaviour
         soap.SetActive(true);
     }
 
-    void GameOver() {
-        OnGameOver?.Invoke();
+    void GameOver(bool isWin) {
+        OnGameOver?.Invoke(isWin);
         player.SetActive(false);
         soap.SetActive(false);
     }
 
     void Defeat() {
-        GameOver();
+        GameOver(false);
+    }
+
+    void Win () {
+        GameOver(true);
     }
 }

--- a/Assets/Main/Scripts/UIManager.cs
+++ b/Assets/Main/Scripts/UIManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 
 public class UIManager : MonoBehaviour
 {
@@ -6,6 +7,7 @@ public class UIManager : MonoBehaviour
 
     [SerializeField] GameObject startUI;
     [SerializeField] GameObject gameOverUI;
+    [SerializeField] Text gameOverMessageContener;
 
     void Awake() {
         GameManager.OnGameOver += DisplayGameOver;
@@ -31,8 +33,25 @@ public class UIManager : MonoBehaviour
         SceneController.ReloadScene();
     }
 
-    void DisplayGameOver(){
+    void DisplayGameOver(bool isWin){
         Debug.Log("Game Over");
         gameOverUI.SetActive(true);
+        if(isWin) {
+            DispayGameOverWinUI();
+        } else {
+            DispayGameOverLoseUI();
+        }
+    }
+
+    void DispayGameOverWinUI() {
+        gameOverMessageContener.color = Color.green;
+        gameOverMessageContener.text = "You Win";
+        Debug.Log("You Win");
+    }
+
+    void DispayGameOverLoseUI() {
+        gameOverMessageContener.color = Color.red;
+        gameOverMessageContener.text = "You Lose";
+        Debug.Log("You Lose");
     }
 }


### PR DESCRIPTION
This pull request includes multiple changes to the `Assets/Main/PlayScene.unity` file and introduces new functionality in the `GameManager` and `UIManager` scripts to handle game win/lose scenarios. The most important changes are grouped into UI adjustments and script updates.

### UI Adjustments:
* Adjusted the `RectTransform` properties for various UI elements, including changes to `m_AnchorMin`, `m_AnchorMax`, `m_AnchoredPosition`, `m_SizeDelta`, and `m_Pivot`. These changes affect the positioning and sizing of UI elements in the PlayScene. [[1]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L290-R294) [[2]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L965-R965) [[3]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L1041-R1045) [[4]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L2087-R2051)
* Removed the `GameObject` and `RectTransform` components associated with the "GameOver" panel and updated the `m_Name` and `m_IsActive` properties of the `GameObject` to reflect this change. [[1]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L1355-L1390) [[2]](diffhunk://#diff-55feed0104f4079f91460c8e9f40ccb23332a2df6a1c54bb02c34ee939d15969L1835-R1825)

### Script Updates:
* Modified the `GameManager` script to include a boolean parameter in the `OnGameOver` event to indicate whether the game was won or lost. Added corresponding methods `Win` and `Defeat` to handle these scenarios. [[1]](diffhunk://#diff-cbefa2c5e1d6dc6a7f9c5034d6a39ae98c604d4f7962c5bc53ed1b95267dc01eR1-R6) [[2]](diffhunk://#diff-cbefa2c5e1d6dc6a7f9c5034d6a39ae98c604d4f7962c5bc53ed1b95267dc01eL28-R40)
* Enhanced the `UIManager` script to display different messages for game win and lose scenarios. Introduced methods `DispayGameOverWinUI` and `DispayGameOverLoseUI` to update the UI accordingly. [[1]](diffhunk://#diff-ed73dd345e2b4891f4cc39ab4ef3eaaf40bdba2a1ca3ff0d4bf93ddba3922fc7R2-R10) [[2]](diffhunk://#diff-ed73dd345e2b4891f4cc39ab4ef3eaaf40bdba2a1ca3ff0d4bf93ddba3922fc7L34-R55)…e game over UI accordingly